### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -17,26 +17,25 @@ class ItemsController < ApplicationController
           end
      end
 
-     # def show
-     #      @item = Item.find(params[:id])
-     # end
+     def show
+          @item = Item.find(params[:id])
+     end
 
-     # def edit
-     #      @item = Item.find(params[:id])
-     #      unless user_signed_in? && current_user.id == @item.user_id
-     #           redirect_to action: :index
-     #      end
-          
-     # end
+     def edit
+          @item = Item.find(params[:id])
+          unless user_signed_in? && current_user.id == @item.user_id
+               redirect_to action: :index
+          end
+     end
 
-     # # def update
-     # #      @item = Item.find(params[:id])
-     # #      if @item.update(item_params)
-     # #           redirect_to root_path
-     # #      else
-     # #           render :edit
-     # #      end
-     # end
+     def update
+          @item = Item.find(params[:id])
+          if @item.update(item_params)
+               redirect_to root_path
+          else
+               render :edit
+          end
+     end
 
 
      private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -46,7 +46,7 @@ class ItemsController < ApplicationController
      end
 
      def move_index
-          unless user_signed_in? && current_user.id == @item.user_id
+          unless current_user.id == @item.user_id
                redirect_to action: :index
           end
      end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
      before_action :authenticate_user!, except: :index
+     before_action :set_item, only: [:show, :edit, :update]
      def index
           @items = Item.includes(:user).order("created_at DESC")
      end
@@ -18,20 +19,17 @@ class ItemsController < ApplicationController
      end
 
      def show
-          @item = Item.find(params[:id])
      end
 
      def edit
-          @item = Item.find(params[:id])
           unless user_signed_in? && current_user.id == @item.user_id
                redirect_to action: :index
           end
      end
 
      def update
-          @item = Item.find(params[:id])
           if @item.update(item_params)
-               redirect_to root_path
+               redirect_to item_path(@item.id)
           else
                render :edit
           end
@@ -43,5 +41,9 @@ class ItemsController < ApplicationController
      def item_params
           params.require(:item).permit(
                :name, :category_id, :info, :image, :sales_status_id, :shipping_fee_status_id, :prefecture_id, :scheduled_delivery_id, :price).merge(user_id: current_user.id)
+     end
+
+     def set_item
+          @item = Item.find(params[:id])
      end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
      before_action :authenticate_user!, except: :index
      before_action :set_item, only: [:show, :edit, :update]
+     before_action :move_index, only: [:edit, :update]
      def index
           @items = Item.includes(:user).order("created_at DESC")
      end
@@ -22,9 +23,6 @@ class ItemsController < ApplicationController
      end
 
      def edit
-          unless user_signed_in? && current_user.id == @item.user_id
-               redirect_to action: :index
-          end
      end
 
      def update
@@ -45,5 +43,11 @@ class ItemsController < ApplicationController
 
      def set_item
           @item = Item.find(params[:id])
+     end
+
+     def move_index
+          unless user_signed_in? && current_user.id == @item.user_id
+               redirect_to action: :index
+          end
      end
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -141,7 +141,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', item_path(@item.id), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,10 +7,10 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%# <%= form_with(model: @item, local: true) do |f| %> %>
+    <%= form_with(model: @item, local: true) do |f| %>
 
 
-    <%# <%= render 'shared/error_messages', model: f.object %> %>
+    <%= render 'shared/error_messages', model: f.object %>
 
 
     <%# 出品画像 %>
@@ -52,12 +52,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%# <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %> %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%# <%= f.collection_select(:sales_status_id, SalesStatus.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %> %>
+        <%= f.collection_select(:sales_status_id, SalesStatus.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +73,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%# <%= f.collection_select(:shipping_fee_status_id, ShippingFeeStatus.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %> %>
+        <%= f.collection_select(:shipping_fee_status_id, ShippingFeeStatus.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%# <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %> %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%# <%= f.collection_select(:scheduled_delivery_id, ScheduledDelivery.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %> %>
+        <%= f.collection_select(:scheduled_delivery_id, ScheduledDelivery.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +101,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%# <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %> %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,13 +1,13 @@
 <%= render "shared/header" %>
 
 <%# 商品の概要 %>
- <div class="item-show">
+<div class="item-show">
   <div class="item-box">
     <h2 class="name">
       <%= @item.name %>
     </h2>
     <div class="item-img-content">
-       <%= image_tag @item.image ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -23,7 +23,8 @@
       </span>
     </div>
 
-<% if user_signed_in? && current_user.id == @item.user_id %>
+    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+
     <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
@@ -31,8 +32,9 @@
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-  <% end %>
 
+
+    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
@@ -41,27 +43,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= @item.user.nickname</td> %>
+          <td class="detail-value"><%= @item.user %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= @item.category.name</td> %>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= @item.sales_status.name</td> %>
+          <td class="detail-value"><%= @item.sales_status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= @item.shipping_fee_status.name</td> %>
+          <td class="detail-value"><%= @item.shipping_fee_status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= @item.prefecture.name</td> %>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= @item.scheduled_delivery.name</td> %>
+          <td class="detail-value"><%= @item.scheduled_delivery.name %></td>
         </tr>
       </tbody>
     </table>
@@ -100,7 +102,9 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class="another-item"><%= @item.category.nameをもっと見る</a> %>
+  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
+  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -22,16 +22,14 @@
         <%= @item.shipping_fee_status.name %>
       </span>
     </div>
-
-<% if user_signed_in? && current_user.id == @item.user_id %>
+<% if user_signed_in? %>
+  <% if current_user.id == @item.user_id %>
     <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-<% end %>
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-<% if user_signed_in? && current_user.id != @item.user_id %>
+  <% else %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
+  <% end %>
 <% end %>
 
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
  <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%# <%= @item.name %> %>
+      <%= @item.name %>
     </h2>
     <div class="item-img-content">
-       <%# <%= image_tag @item.image ,class:"item-box-img" %> %>
+       <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -16,14 +16,14 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        <%# ¥<%= @item.price %> %>
+        ¥<%= @item.price %>
       </span>
       <span class="item-postage">
-        <%# <%= @item.shipping_fee_status.name %> %>
+        <%= @item.shipping_fee_status.name %>
       </span>
     </div>
 
-<%# <% if user_signed_in? && current_user.id == @item.user_id %> %>
+<% if user_signed_in? && current_user.id == @item.user_id %>
     <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
@@ -41,27 +41,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <%# <td class="detail-value"><%= @item.user.nickname %></td> %>
+          <td class="detail-value"><%= @item.user.nickname</td> %>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <%# <td class="detail-value"><%= @item.category.name %></td> %>
+          <td class="detail-value"><%= @item.category.name</td> %>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <%# <td class="detail-value"><%= @item.sales_status.name %></td> %>
+          <td class="detail-value"><%= @item.sales_status.name</td> %>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <%# <td class="detail-value"><%= @item.shipping_fee_status.name %></td> %>
+          <td class="detail-value"><%= @item.shipping_fee_status.name</td> %>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <%# <td class="detail-value"><%= @item.prefecture.name %></td> %>
+          <td class="detail-value"><%= @item.prefecture.name</td> %>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <%# <td class="detail-value"><%= @item.scheduled_delivery.name %></td> %>
+          <td class="detail-value"><%= @item.scheduled_delivery.name</td> %>
         </tr>
       </tbody>
     </table>
@@ -100,7 +100,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a> %>
+  <a href="#" class="another-item"><%= @item.category.nameをもっと見る</a> %>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,18 +23,17 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+<% if user_signed_in? && current_user.id == @item.user_id %>
     <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
+<% end %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
+<% if user_signed_in? && current_user.id != @item.user_id %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
+<% end %>
 
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
@@ -43,7 +42,7 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= @item.user %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
@@ -102,9 +101,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
   <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 
 <%= render "shared/footer" %>


### PR DESCRIPTION
# What
商品情報を編集、更新できる機能を実装した

# Why
商品情報を変更したい場合に変更できるようにするため


ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/4b9bbb57af4e41ca75b5c0905ed87c13

正しく情報を記入すると、商品の情報を編集できる動画
https://gyazo.com/9eb6379f3e5060150ffe351ea52d5b67

入力に問題のある状態では商品の情報は編集できず、エラーメッセージが出力される動画
https://gyazo.com/1195500841bdee18e5fdf0819294b9ff

何も編集せずに更新をしても画像無しの商品にならない動画
https://gyazo.com/a3af92e80aaab002056accdfc65e2c5c

ログイン状態のユーザーであっても、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/eda930a0d6ca12790fa4a9e092a076be

ログアウト状態のユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移する動画
https://gyazo.com/d697d9306b197dfbd1f3db42816eec2c

商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（画像に関しては、表示されない状態で良い）
https://gyazo.com/dfe858d38a5d90c8cf40f8c3c83830fb